### PR TITLE
Add check for signature streaming v4

### DIFF
--- a/cmd/requests.go
+++ b/cmd/requests.go
@@ -34,6 +34,9 @@ type Request struct {
 	presignURL bool  // Indicates whether or not this will be a presigned http.Request.
 	expires    int64 // Describes for how long the presigned URL will be valid for.
 
+	streamingSign bool
+	chunkSize     int64
+
 	customHeader http.Header
 	contentBody  io.Reader
 
@@ -155,6 +158,8 @@ func (c ServerConfig) newRequest(method string, customReq Request) (req *http.Re
 	} else if customReq.presignURL {
 		// Presign the request.
 		req = signv4.PreSignV4(*req, c.Access, c.Secret, c.Region, customReq.expires)
+	} else if customReq.streamingSign {
+		req = signv4.StreamingSignV4(*req, c.Access, c.Secret, c.Region, customReq.chunkSize)
 	} else {
 		// Else use regular signature v4.
 		req = signv4.SignV4(*req, c.Access, c.Secret, c.Region)

--- a/cmd/tests.go
+++ b/cmd/tests.go
@@ -67,6 +67,13 @@ var preparedTests = []APItest{
 		Extended: false, // PutObject is not an extended API.
 		Critical: false, // Because -- has been used this object is not necessary for future tests.
 	},
+	// Tests for PutObject streaming API.
+	APItest{
+		Test:     mainPutObjectStream,
+		Extended: false, // PutObject streaming v4 is not an extended API.
+		Critical: false, // Because -- has been used this object is not necessary for future tests.
+	},
+
 	APItest{
 		Test:     mainPresignedPutObject,
 		Extended: false, // PutObject presigned is not an extended API.
@@ -291,6 +298,13 @@ var unpreparedTests = []APItest{
 		Extended: false, // PutObject is not an extended API.
 		Critical: true,  // These objects are necessary for future tests.
 	},
+	// Tests for PutObject Streaming API.
+	APItest{
+		Test:     mainPutObjectStream,
+		Extended: false, // PutObject Streaming V4 is not an extended API.
+		Critical: true,  // These objects are necessary for future tests.
+	},
+
 	APItest{
 		Test:     mainPresignedPutObject,
 		Extended: false, // PutObject presigned is not an extended API.


### PR DESCRIPTION
Streaming signature v4 is different than other S3 processes. The most simple thing that I was able to do is to regenerate signed chunks in signV4 itself after signing the request

Fixes #209 