### PR TITLE
Tests: change default suffix to tmp-bkt to avoid redirect issues

### DIFF
--- a/cmd/globals.go
+++ b/cmd/globals.go
@@ -88,7 +88,7 @@ func setGlobalsFromContext(ctx *cli.Context) error {
 		}
 	}
 	// Standard suffix.
-	suffix := "tmp-bucket"
+	suffix := "tmp-bkt"
 	if ctx.GlobalString("id") != "" {
 		suffix = ctx.GlobalString("id")
 	}


### PR DESCRIPTION
With the original suffix: "tmp-bucket" s3verify was running into 301 redirect errors and deleting the buckets has not been working. This is a workaround until the original suffix is made usable again.