### PR TITLE
Add  `X-Amz-Bucket-Region` to the list of valid response headers.

### DIFF
--- a/cmd/utils.go
+++ b/cmd/utils.go
@@ -79,6 +79,7 @@ var validResponseHeaders = map[string]struct{}{
 	"x-amz-id-2":          struct{}{},
 	"x-amz-request-id":    struct{}{},
 	"x-amz-version-id":    struct{}{},
+	"x-amz-bucket-region": struct{}{},
 }
 
 // printMessage - Print test pass/fail messages with errors.


### PR DESCRIPTION
Fixes https://github.com/minio/s3verify/issues/238 . 